### PR TITLE
Fix default copilot setup script

### DIFF
--- a/scripts/init-empty-copilot-project.sh
+++ b/scripts/init-empty-copilot-project.sh
@@ -4,13 +4,13 @@
 mkdir -p .github/prompts
 mkdir -p memory-bank
 mkdir -p .vscode
+mkdir -p .clinerules
 
 # Must not introduce noticeable side-effects.
 # Must be pure unless the things that must exist do not exist.
 # Create necessary files without overwriting existing ones.
 [ -f .github/copilot-instructions.md ] || touch .github/copilot-instructions.md
-[ -f .clinerules ] || touch .clinerules
-[ -f codex.md ] || touch codex.md
+[ -f AGENTS.md ] || touch AGENTS.md
 [ -f .github/prompts/default.prompt.md ] || touch .github/prompts/default.prompt.md
 [ -f .vscode/settings.json ] || touch .vscode/settings.json
 


### PR DESCRIPTION
## Summary
- create `.clinerules` directory and stop creating deprecated `codex.md`
- ensure `AGENTS.md` is initialized for copilot

## Testing
- `bash -n scripts/init-empty-copilot-project.sh`
- `bash scripts/init-empty-copilot-project.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f67e4cb54833191586440abab61a5