### PR TITLE
Fix Python README and add script utilities

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+MD013: false
+MD033: false

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,3 @@
-
 # Python Directory
 
 This directory contains all Python source code, modules, and environment configuration for the project.
@@ -14,4 +13,4 @@ This directory contains all Python source code, modules, and environment configu
 - `Dockerfile` — Container build for Python environment
 - `README.md` — Setup and usage instructions
 
-See [../.github/instructions/python-environment.instructions.md](../.github/instructions/python-environment.instructions.md) for full environment standards.
+See [python-environment.instructions.md](../.github/instructions/python-environment.instructions.md) for full environment standards.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,16 +1,45 @@
-# Scripts Directory
+# `scripts/` Directory
 
-This directory contains all automation and setup scripts for the project.
+This folder contains utility scripts for setting up, validating, and maintaining the repository.  
+**All scripts must pass strict markdown-lint on any Markdown they generate or update.**
 
-## Purpose
-- Automate environment setup for local and Docker workflows
-- Ensure idempotent, safe, and repeatable setup
-- Store only shell scripts related to project automation
+## Conventions
+1. **Shebang & Strict Mode**  
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+   ```
+2. **Idempotent Operations**
+   Before creating a directory or file, check if it already exists:
 
-## Structure
-- `setup_python_local.sh` — Local Python venv setup
-- `setup_python_docker.sh` — Docker image build for Python
+   ```bash
+   if [ ! -d "some_dir" ]; then
+     mkdir -p "some_dir"
+     echo "[`date '+%Y-%m-%dT%H:%M:%S%z'`] Created some_dir"
+   else
+     echo "[`date '+%Y-%m-%dT%H:%M:%S%z'`] some_dir already exists"
+   fi
+   ```
+3. **Timestamped Logging**
+   Every major step must echo a log line in [YYYY-MM-DDThh:mm:ssZ] format.
+4. **Markdown-lint Verification**
+   If a script modifies any *.md, it must run:
 
-All scripts are idempotent and do not overwrite existing environments or files.
+   ```bash
+   markdownlint --config .markdownlint.yaml <path/to/file>.md
+   ```
 
-See [../.github/instructions/python-environment.instructions.md](../.github/instructions/python-environment.instructions.md) for standards.
+   and exit non-zero if lint errors occur.
+
+## Script Index
+- `setup_project.sh` — Base scaffolding (no overwrites)
+- `setup_python_local.sh` — Sets up Python venv + dependencies
+- `setup_python_docker.sh` — Builds Python Docker image
+- `check-dependencies.sh` — Verifies memory-bank/dependencies.md structure
+- `check-memory-bank.sh` — Runs markdownlint on memory-bank/*.md
+- `validate-instructions.sh` — Lints .github/instructions/*.instructions.md
+- `validate-prompt.sh` — Lints .github/prompts/*.prompt.md
+- `check-markdown.sh` — Runs markdownlint on all Markdown files in repo
+
+## Verification
+- Run `markdownlint --config .markdownlint.yaml scripts/README.md`

--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+FILE="memory-bank/dependencies.md"
+
+if [ ! -f "$FILE" ]; then
+  log "[ERROR] $FILE not found"
+  exit 1
+fi
+
+if grep -q "Dependencies and Relationships" "$FILE"; then
+  log "dependencies.md structure valid"
+else
+  log "[ERROR] dependencies.md missing structure"
+  exit 1
+fi
+
+log "Verifying Markdown compliance…"
+markdownlint --config .markdownlint.yaml "$FILE" || {
+  echo "[ERROR] $FILE failed markdownlint."
+  exit 1
+}

--- a/scripts/check-markdown.sh
+++ b/scripts/check-markdown.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+log "Running markdownlint on all tracked markdown files"
+files=$(git ls-files '*.md')
+markdownlint --config .markdownlint.yaml $files || {
+  echo "[ERROR] markdownlint failed"
+  exit 1
+}

--- a/scripts/check-memory-bank.sh
+++ b/scripts/check-memory-bank.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+dir="memory-bank"
+
+if [ ! -d "$dir" ]; then
+  log "[ERROR] $dir not found"
+  exit 1
+fi
+
+log "Running markdownlint on $dir/*.md"
+markdownlint --config .markdownlint.yaml "$dir"/*.md || {
+  echo "[ERROR] Markdownlint failed for $dir"
+  exit 1
+}

--- a/scripts/setup_python_docker.sh
+++ b/scripts/setup_python_docker.sh
@@ -1,6 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Idempotent Docker Python environment setup script
-set -e
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
 cd "$(dirname "$0")/../python"
-docker build -t my-python-app .
-echo "Docker Python image built."
+
+if docker image inspect my-python-app >/dev/null 2>&1; then
+  log "Docker image 'my-python-app' already exists"
+else
+  log "Building Docker image 'my-python-app'"
+  docker build -t my-python-app .
+  log "Docker Python image built"
+fi

--- a/scripts/setup_python_local.sh
+++ b/scripts/setup_python_local.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Python Local Virtual Environment Setup
 # Creates a local virtual environment for Python development
 
-set -e
+set -euo pipefail
 
 # Import environment variables from main script
 PYTHON_DIR="${PYTHON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../python" && pwd)}"
@@ -17,7 +17,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 log() {
-    echo -e "${BLUE}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1"
+  echo -e "${BLUE}[$(date -u +'%Y-%m-%dT%H:%M:%SZ')]${NC} $1"
 }
 
 warn() {
@@ -241,6 +241,12 @@ For more information, see:
 - Instructions: \`../.github/instructions/python-environment-conditional.instructions.md\`
 - Prompt: \`../.github/prompts/python-environment-setup.prompt.md\`
 EOF
+
+log "Verifying Markdown compliance…"
+markdownlint --config .markdownlint.yaml "$README_FILE" || {
+  echo "[ERROR] $README_FILE failed markdownlint."
+  exit 1
+}
 
 success "Updated README.md with local environment instructions"
 

--- a/scripts/validate-instructions.sh
+++ b/scripts/validate-instructions.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+pattern=".github/instructions/*.instructions.md"
+
+log "Linting instructions files"
+markdownlint --config .markdownlint.yaml $pattern || {
+  echo "[ERROR] instructions markdownlint failed"
+  exit 1
+}

--- a/scripts/validate-prompt.sh
+++ b/scripts/validate-prompt.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $1"
+}
+
+pattern=".github/prompts/*.prompt.md"
+
+log "Linting prompt files"
+markdownlint --config .markdownlint.yaml $pattern || {
+  echo "[ERROR] prompt markdownlint failed"
+  exit 1
+}


### PR DESCRIPTION
## Summary
- fix malformed link and remove leading blank line in python/README.md
- add markdownlint config
- overhaul setup scripts with strict bash headers and timestamp logging
- add validation scripts for markdown and dependencies
- document script conventions in scripts/README.md

## Testing
- `markdownlint --config .markdownlint.yaml python/README.md` *(fails: command not found)*
- `markdownlint --config .markdownlint.yaml scripts/README.md` *(fails: command not found)*
- `bash scripts/check-markdown.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f96eb14208331af1371a1353002bf