### PR TITLE
Add markdownlint/Prettier tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-# Placeholder for .gitignore
+node_modules/
+package-lock.json

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,5 @@
+config: .markdownlint.yaml
+fix: true
+ignores:
+
+- node_modules

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+printWidth: 80
+singleQuote: true
+trailingComma: es5
+semi: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,11 +90,14 @@
     "source.fixAll": "always",
     "source.fixAll.eslint": "explicit",
     "source.fixAll.prettier": "always",
+    "source.fixAll.markdownlint": "always",
     "source.organizeImports": "explicit",
     "source.sortImports": "always",
 
     "source.fixAll.ts": "explicit"
   },
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   "editor.inlineSuggest.showToolbar": "always",
   "editor.minimap.renderCharacters": false,
   "editor.minimap.showSlider": "always",

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Coding standards that are automatically applied during AI-assisted development:
 - **Memory Bank Integration:** All components reference and update dependency tracking
 - **Markdown-lint Compliance:** All files follow strict markdown formatting requirements
 
+## Formatting and Linting
+
+Run Prettier and markdownlint to keep files consistent:
+
+```bash
+npm install
+npm run format       # Prettier fixes formatting
+npm run lint:md      # Check Markdown
+npm run lint:md:fix  # Auto-fix Markdown issues
+```
+
+Auto format on save is enabled via `.vscode/settings.json` when the
+relevant extensions are installed.
+
 ---
 
 > This README and all scripts must remain markdown-lint strict mode compliant at all times.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codex-k3",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "format": "prettier --write \"**/*.{js,ts,md,json,yml,yaml}\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint:md:fix": "markdownlint-cli2-fix \"**/*.md\"",
+    "lint": "npm run lint:md && npm run format"
+  },
+  "devDependencies": {
+    "markdownlint-cli2": "^0.18.1",
+    "prettier": "^3.5.3"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Prettier via `.prettierrc.yaml`
- enable markdownlint CLI2 with autofix settings
- ignore `node_modules` and package-lock
- document lint workflow in README
- enable auto fix on save for markdownlint and Prettier in VS Code

## Testing
- `npx markdownlint-cli2 README.md`
- `scripts/verify-all.sh` *(fails: markdownlint-cli2 reported many errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858865169b88331adc2eadaca5cc355