### PR TITLE
Add Prettier and markdownlint tooling

### DIFF
--- a/.github/instructions/markdownlint.instructions.md
+++ b/.github/instructions/markdownlint.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "**/*.md"
+---
+
+# Markdownlint Standards
+
+## Purpose
+
+Provide consistent Markdown formatting across the repository.
+
+## Usage
+
+- Install the CLI tools with `npm install --save-dev markdownlint markdownlint-cli`.
+- Run `npx markdownlint --fix "**/*.md"` to automatically apply fixes.
+- Repository verification uses `scripts/check-markdown.sh`.
+- VS Code users should install the `DavidAnson.vscode-markdownlint` extension for auto-fix on save.
+
+See <https://github.com/DavidAnson/markdownlint> for complete documentation.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+*.log
+python/.venv/
+python/__pycache__/

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,5 @@
+semi: true
+singleQuote: true
+printWidth: 80
+trailingComma: es5
+tabWidth: 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,8 +71,8 @@
     */
   // #region: FORMAT BEHAVIOUR                                               !
   // "editor.formatOnPaste": false,
-  // "editor.formatOnSave": true,
-  // "editor.formatOnSaveMode": "file",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   // "editor.formatOnType": false,
   // "editor.suggest.showFiles": true,
   // "editor.suggest.showFolders": true,

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ All operational rules and protocols are maintained in the modular files under `.
     - `README.md` (file)
     - `AGENTS.md` (file, replaces any use of `codex.md`)
     - `memory-bank/dependencies.md` (file)
+
 ## AGENTS.md Migration
 
 - `AGENTS.md` is now the default repository context/instructions markdown file for Codex CLI and related tools.
@@ -94,6 +95,7 @@ Code is organized by language and framework at the project root:
 ## Script Validation and Logging
 
 The `scripts/setup_project.sh` script now includes:
+
 - File existence and size checks before writing
 - Directory creation with `mkdir -p` and validation
 - Logging of all actions (creation, skipping, size reporting)
@@ -109,6 +111,7 @@ This project includes a modular AI agent framework for automated code generation
 ### Prompt Files (`.github/prompts/`)
 
 Parametric prompt templates for AI-assisted development workflows:
+
 - **`ai-template-manager.prompt.md`** — Enhanced template generation with parametric inputs
 - **`script-generator.prompt.md`** — Resilient automation script generation
 - **`docker-generator.prompt.md`** — Parameterized Docker configuration generation
@@ -118,6 +121,7 @@ Parametric prompt templates for AI-assisted development workflows:
 ### Instruction Files (`.github/instructions/`)
 
 Coding standards that are automatically applied during AI-assisted development:
+
 - **`typescript-standards.instructions.md`** — Comprehensive TypeScript coding standards
 - **`python-standards.instructions.md`** — PEP 8 and modern Python practices
 - **`python-notebook-standards.instructions.md`** — Jupyter notebook standards and ML best practices
@@ -136,6 +140,15 @@ Coding standards that are automatically applied during AI-assisted development:
 - **Standards Enforcement:** Automatic application of coding standards during generation
 - **Memory Bank Integration:** All components reference and update dependency tracking
 - **Markdown-lint Compliance:** All files follow strict markdown formatting requirements
+
+### Formatting and Linting
+
+This project enforces automatic formatting and linting.
+
+- **Prettier**: configuration in `.prettierrc.yaml`. Run `scripts/check-prettier.sh` or `npx prettier --write` to fix files.
+- **Markdownlint**: configuration in `.markdownlint.yaml`. Run `scripts/check-markdown.sh` or `npx markdownlint --fix "**/*.md"`.
+
+VS Code users can enable format-on-save with the Prettier and markdownlint extensions.
 
 ---
 

--- a/scripts/check-prettier.sh
+++ b/scripts/check-prettier.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validate Prettier formatting across the repository
+# Cross-Reference: .clinerules/verification.md
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/logging.sh"
+
+log_info "Checking Prettier formatting"
+files=$(git ls-files '*.js' '*.ts' '*.tsx' '*.jsx' '*.json' '*.yaml' '*.yml' '*.md')
+if npx prettier --version >/dev/null 2>&1; then
+  npx prettier --check $files || {
+    log_error "Prettier formatting issues found"
+    exit 1
+  }
+else
+  log_error "Prettier is not installed"
+  exit 1
+fi
+
+# Verification
+# Run `scripts/verify-all.sh` to include this check.

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -8,6 +8,7 @@ source "$SCRIPT_DIR/lib/logging.sh"
 log_info "Running full repository verification"
 
 scripts/check-markdown.sh
+scripts/check-prettier.sh
 scripts/check-dependencies.sh
 scripts/check-memory-bank.sh
 


### PR DESCRIPTION
## Summary
- configure Prettier using `.prettierrc.yaml`
- ignore build artefacts in `.prettierignore`
- add markdownlint instructions for Copilot use
- add Prettier check script and integrate with `verify-all.sh`
- update README with formatting and linting section
- enable format on save in VS Code settings

## Testing
- `npm install -g markdownlint-cli`
- `scripts/verify-all.sh` *(fails: markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858865169b88331adc2eadaca5cc355