### PR TITLE
Add markdownlint + Prettier automation

### DIFF
--- a/.clinerules/verification.md
+++ b/.clinerules/verification.md
@@ -4,8 +4,9 @@
 1. Check all Memory Bank files for updates before starting work.
 2. Verify that all changes are made via scripts in the scripts/ directory.
 3. Validate markdown-lint compliance for all documentation.
-4. Confirm that cross-references are up to date across files.
-5. Test documentation completeness and consistency.
+4. Run `scripts/fix-markdown.sh` to apply automatic formatting.
+5. Confirm that cross-references are up to date across files.
+6. Test documentation completeness and consistency.
 
 ## Guidance
 - Use this checklist before, during, and after each round of work.

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,5 @@
+printWidth: 80
+singleQuote: true
+semi: true
+proseWrap: always
+endOfLine: lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,12 +22,17 @@
   "terminal.integrated.persistentSessionReviveProcess": "never",
   "terminal.integrated.localEchoLatencyThreshold": 30,
 
+  "editor.formatOnSave": true,
+
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[markdown]": {
     "diffEditor.ignoreTrimWhitespace": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": true
+    }
   },
   "[typescript]": {
     "editor.defaultFormatter": "vscode.typescript-language-features"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ All prompts, instruction files, and scripts must end with a **Verification** sec
 This block reminds contributors to run:
 
 - `markdownlint --strict` on all updated Markdown files
+- `scripts/fix-markdown.sh` to apply Prettier and markdownlint fixes
 - Any relevant validation scripts such as `scripts/verify-all.sh`
 
 Failure to include this block or run the checks is considered non-compliant.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Coding standards that are automatically applied during AI-assisted development:
 - **Memory Bank Integration:** All components reference and update dependency tracking
 - **Markdown-lint Compliance:** All files follow strict markdown formatting requirements
 
+## Markdownlint and Prettier
+
+This repository uses **markdownlint** and **Prettier** for automatic formatting.
+
+- Run `scripts/fix-markdown.sh` to apply Prettier and markdownlint fixes across all Markdown files.
+- `scripts/verify-all.sh` invokes this script along with other checks.
+- In VS Code, install the `vscode-markdownlint` and `Prettier` extensions to format and fix files on save.
+
 ---
 
 > This README and all scripts must remain markdown-lint strict mode compliant at all times.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -51,6 +51,7 @@ Current work focuses on hardening automation scripts for repeatable use. Tasks i
 - Update `memory-bank/docker-workflow.md` with new conditional Docker patterns
 - Update `memory-bank/progress.md` with completed framework status
 - Record script-resilience improvements, including logging library and force options
+- Add `scripts/fix-markdown.sh` for Prettier and markdownlint automation
 
 ### Testing
 - Run each environment mode to validate behavior

--- a/memory-bank/dependencies.md
+++ b/memory-bank/dependencies.md
@@ -55,6 +55,10 @@ This file tracks all project dependencies, their relationships, and integration 
 - **Web Framework**: Next.js application in `web/` (when applicable)
 
 ## Development Dependencies
+### Documentation Linters
+- **markdownlint**: Enforces Markdown style and supports automatic fixes.
+- **Prettier**: Formats Markdown consistently and integrates with markdownlint.
+
 
 ### Conditional Python Environment System
 - **Runtime Parameter System**:

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -31,6 +31,7 @@ This file tracks what works, what remains to be built, current status, and known
 - Repository documentation updated to reference new rules
 - Python standards instruction file published
 - VS Code settings updated for Copilot 1.101+
+- Markdownlint and Prettier automation via `scripts/fix-markdown.sh`
 
 <!-- ai:section:whats-left -->
 ## What's Left

--- a/scripts/fix-markdown.sh
+++ b/scripts/fix-markdown.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Format all Markdown files using Prettier and markdownlint --fix
+# Cross-Reference: .clinerules/verification.md for lint protocol.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/logging.sh"
+
+log_info "Formatting Markdown files with Prettier"
+files=$(git ls-files '*.md')
+if command -v npx >/dev/null 2>&1; then
+  npx prettier --write $files
+else
+  log_warn "npx not found; skipping Prettier formatting"
+fi
+
+log_info "Applying markdownlint fixes"
+if markdownlint --help | grep -q -- '--fix'; then
+  markdownlint --fix --config .markdownlint.yaml $files
+else
+  markdownlint --config .markdownlint.yaml $files
+fi
+
+log_success "Markdown formatting complete"
+
+# Verification
+# Run `scripts/verify-all.sh` to execute this lint step.

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -7,6 +7,7 @@ source "$SCRIPT_DIR/lib/logging.sh"
 
 log_info "Running full repository verification"
 
+scripts/fix-markdown.sh
 scripts/check-markdown.sh
 scripts/check-dependencies.sh
 scripts/check-memory-bank.sh


### PR DESCRIPTION
## Summary
- add `.prettierrc.yaml` and `scripts/fix-markdown.sh`
- integrate fix script into verification workflow
- enable auto formatting in VS Code settings
- document lint/format rules in README
- update Memory Bank with new tooling

## Testing
- `scripts/verify-all.sh` *(fails: markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858865169b88331adc2eadaca5cc355