### PR TITLE
Integrate linting configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps maintain consistent coding styles
+# See: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 100
+trim_trailing_whitespace = false
+
+[*.{json,yaml,yml}]
+indent_size = 2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,50 +1,78 @@
-MD001: true
-MD002: true
-MD003: true
-MD004: true
-MD005: true
-MD006: true
-MD007: true
-MD008: true
-MD009: true
-MD010: true
-MD011: true
-MD012: true
-MD013: true
-MD014: true
-MD015: true
-MD016: true
-MD017: true
-MD018: true
-MD019: true
-MD020: true
-MD021: true
-MD022: true
-MD023: true
-MD024: true
-MD025: true
-MD026: true
-MD027: true
-MD028: true
-MD029: true
-MD030: true
-MD031: true
-MD032: true
-MD033: true
-MD034: true
-MD035: true
-MD036: true
-MD037: true
-MD038: true
-MD039: true
-MD040: true
-MD041: true
-MD042: true
-MD043: true
-MD044: true
-MD045: true
-MD046: true
-MD047: true
-MD048: true
-MD049: true
-MD050: true
+---
+# Markdownlint Configuration (https://github.com/DavidAnson/markdownlint)
+# Enforce strict rules with autofixable options enabled
+
+default: true  # Enable all rules by default
+
+# Customize specific rules
+MD003:
+  style: "consistent"  # Heading style must be consistent
+
+MD004:
+  style: "dash"  # Unordered list style must use dashes
+
+MD007:
+  indent: 2  # Unordered list indentation = 2 spaces
+
+MD009:
+  strict: true  # No trailing spaces except when needed
+
+MD010: true  # No hard tabs
+
+MD012:
+  maximum: 1  # Maximum 1 consecutive blank line
+
+MD013:
+  line_length: 100
+  code_blocks: false
+  tables: false
+
+MD022:
+  lines_above: 1
+  lines_below: 1  # Headings must be surrounded by blank lines
+
+MD024:
+  allow_different_nesting: true  # Allow same heading text in different contexts
+
+MD025:
+  level: 1  # Only one top-level heading
+
+MD030:
+  ul_single: 1
+  ol_single: 1
+  ul_multi: 1
+  ol_multi: 1  # Enforce spacing for list markers
+
+MD031: true  # Fenced code blocks should be surrounded by blank lines
+
+MD032: true  # Lists should be surrounded by blank lines
+
+MD033:
+  allowed_elements:
+    - "br"
+    - "img"  # Allow only specific HTML elements
+
+MD034: true  # Bare URLs should be enclosed in angle brackets
+
+MD035:
+  style: "---"  # Horizontal rules should use consistent style
+
+MD040: true  # Fenced code blocks should have language specified
+
+MD041: true  # First line in a file should be a top-level heading
+
+MD046:
+  style: "consistent"  # Code block style must be consistent
+
+MD047: true  # Files should end with a single newline character
+
+MD048:
+  style: "backtick"  # Code fence style
+
+MD049:
+  style: "asterisk"  # Emphasis style
+
+MD050:
+  style: "asterisk"  # Strong emphasis style
+
+MD055: true  # Table pipe style

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,18 @@
+---
+# Prettier Configuration (https://prettier.io/docs/en/options.html)
+
+printWidth: 100        # Line length where Prettier will try wrap
+tabWidth: 2            # Number of spaces per indentation level
+useTabs: false         # Use spaces instead of tabs
+semi: true             # Add semicolons at the end of statements
+singleQuote: true      # Use single quotes instead of double quotes
+quoteProps: "as-needed" # Only add quotes around object properties when needed
+jsxSingleQuote: false  # Use double quotes in JSX
+trailingComma: "es5"   # Add trailing commas where valid in ES5
+bracketSpacing: true   # Print spaces between brackets in object literals
+bracketSameLine: false # Put the > of a multi-line HTML element at the end of the last line
+arrowParens: "always"  # Include parentheses around a sole arrow function parameter
+proseWrap: "preserve"  # Don't change wrapping in markdown files
+htmlWhitespaceSensitivity: "css" # HTML whitespace handling
+endOfLine: "lf"        # Line endings (LF for cross-platform compatibility)
+embeddedLanguageFormatting: "auto" # Format embedded code

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "davidanson.vscode-markdownlint",
+    "editorconfig.editorconfig",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/LINTING.md
+++ b/LINTING.md
@@ -1,0 +1,20 @@
+# Linting & Formatting
+
+## Markdown
+
+- Uses [markdownlint](https://github.com/DavidAnson/markdownlint).
+- Config: `.markdownlint.yaml`
+- Run: `npm run lint:md` (autofix enabled)
+
+## Prettier
+
+- Uses [Prettier](https://prettier.io/).
+- Config: `.prettierrc.yaml`
+- Run: `npm run format:prettier` (autofix enabled)
+
+## VS Code
+
+- Recommended Extensions: `esbenp.prettier-vscode`, `DavidAnson.vscode-markdownlint`
+- Auto-fix on save is enabled.
+
+> All contributors and AI agents must ensure all code is autofixed before commit. Autofix is mandatory.

--- a/LINTING_GUIDE.md
+++ b/LINTING_GUIDE.md
@@ -1,0 +1,80 @@
+# Linting & Formatting Guide
+
+This project enforces strict code quality standards through automated linting
+and formatting. All contributors, including AI agents, must adhere to these standards.
+
+## Tools & Configuration
+
+### Markdownlint
+
+[Markdownlint](https://github.com/DavidAnson/markdownlint) is used for Markdown linting.
+
+- **Config file**: `.markdownlint.yaml`
+- **Autofixable rules**: Enabled and required
+
+```bash
+# Lint and fix all Markdown files
+npm run lint:md
+```
+
+### Prettier
+
+[Prettier](https://prettier.io/) is used for code formatting.
+
+- **Config file**: `.prettierrc.yaml`
+- **Supported files**: Markdown, JSON, YAML, etc.
+
+```bash
+# Format all files
+npm run format:prettier
+```
+
+## Automated Workflows
+
+### VS Code Integration
+
+Install the recommended extensions (will be prompted automatically):
+
+- `esbenp.prettier-vscode`
+- `davidanson.vscode-markdownlint`
+
+VS Code is configured to:
+
+- Format on save
+- Apply autofix on save
+- Show linting errors inline
+
+### Command Line Usage
+
+```bash
+# Check formatting without fixing
+npm run lint
+
+# Fix all linting and formatting issues
+npm run format
+
+# Run before committing changes
+npm run format
+```
+
+### Git Hooks
+
+The project uses Husky and lint-staged to:
+
+- Automatically lint and format files on pre-commit
+- Prevent commits with unfixable linting errors
+
+## Requirements for Contributors
+
+1. **All code must pass linting**: Failure to comply will block commits
+2. **Autofixable issues must be fixed**: Use `npm run format` before committing
+3. **Minimize the need for autofixes**: Write compliant code from the start
+
+## For AI Agents
+
+AI agents (GitHub Copilot, etc.) must:
+
+- Write code that follows all linting rules to minimize autofix needs
+- Include proper formatting for all generated content
+- Be aware of the project's linting rules when suggesting code
+- Ensure Markdown content has proper heading structure, spacing, and formatting

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "scripts": {
+    "lint:md": "markdownlint '**/*.md' --fix",
+    "lint:prettier": "prettier --check .",
+    "format:prettier": "prettier --write .",
+    "format": "npm run lint:md && npm run format:prettier",
+    "lint": "npm run lint:md && npm run lint:prettier",
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "markdownlint": "^0.32.1",
+    "markdownlint-cli": "^0.37.0",
+    "prettier": "^3.1.0",
+    "husky": "^8.0.3",
+    "lint-staged": "^15.1.0"
+  },
+  "lint-staged": {
+    "*.md": [
+      "markdownlint --fix",
+      "prettier --write"
+    ],
+    "*.{json,yaml,yml}": [
+      "prettier --write"
+    ]
+  }
+}

--- a/scripts/setup_linting.sh
+++ b/scripts/setup_linting.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Install dependencies
+npm install --save-dev markdownlint markdownlint-cli prettier husky lint-staged
+
+# Initialize husky
+npx husky install
+
+# Make the pre-commit hook executable
+chmod +x .husky/pre-commit
+
+# Install recommended VS Code extensions if VS Code is installed and extensions CLI is available
+if command -v code &> /dev/null; then
+  code --install-extension esbenp.prettier-vscode
+  code --install-extension davidanson.vscode-markdownlint
+  code --install-extension editorconfig.editorconfig
+  code --install-extension streetsidesoftware.code-spell-checker
+  echo "VS Code extensions installed successfully."
+else
+  echo "VS Code not found or extensions CLI not available. Install the recommended extensions manually."
+fi
+
+echo "Linting and formatting setup complete!"


### PR DESCRIPTION
## Summary
- add editorconfig, prettier configuration, and Husky hook
- add npm scripts for linting and formatting
- provide linting documentation
- script for setting up linting tooling

## Testing
- `npx markdownlint --config .markdownlint.yaml LINTING.md LINTING_GUIDE.md`
- `PATH=$(pwd)/node_modules/.bin:$PATH scripts/verify-all.sh` *(fails: markdownlint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68589a5967488331b4685c6cd79fd6ca